### PR TITLE
set nsfw to True to retrieve all list entries

### DIFF
--- a/pyMALv2/services/user_service/user_anime_list.py
+++ b/pyMALv2/services/user_service/user_anime_list.py
@@ -89,7 +89,7 @@ class UserAnimeList(Base):
         results = []
         while True:
             r = self._request('GET', MAL_GET_ANIME_LIST_ENDPOINT(),
-                              params={'limit': 1000, 'fields': 'list_status', offset: offset})
+                              params={'limit': 1000, 'fields': 'list_status', offset: offset, 'nsfw': True})
             page = json.loads(r.text)
 
             for entry in page['data']:

--- a/pyMALv2/services/user_service/user_manga_list.py
+++ b/pyMALv2/services/user_service/user_manga_list.py
@@ -89,7 +89,7 @@ class UserMangaList(Base):
         results = []
         while True:
             r = self._request('GET', MAL_GET_MANGA_LIST_ENDPOINT(),
-                              params={'limit': 1000, 'fields': 'list_status', offset: offset})
+                              params={'limit': 1000, 'fields': 'list_status', offset: offset, 'nsfw': True})
             page = json.loads(r.text)
 
             for entry in page['data']:


### PR DESCRIPTION
Hey I was using your library and noticed that I wasn't able to retrieve all list entries because MAL by default omits NSFW entries, which has a pretty liberal definition. I couldn't figure out how to run the tests unfortunately but feel free to edit this to comply with your standards.

See https://myanimelist.net/apiconfig/references/api/v2#section/Common-parameters for more info.